### PR TITLE
feat: add shape morphing navigation pills

### DIFF
--- a/app/src/main/java/com/sidharthify/breathe/MainActivity.kt
+++ b/app/src/main/java/com/sidharthify/breathe/MainActivity.kt
@@ -1,5 +1,13 @@
 package com.sidharthify.breathe
 
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import android.app.Activity
 import android.content.Context
 import android.os.Build
@@ -12,11 +20,9 @@ import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
-import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
-import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -25,7 +31,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
@@ -34,10 +39,10 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.sidharthify.breathe.navigation.AppScreen
+import com.sidharthify.breathe.ui.components.MorphingPill
 import com.sidharthify.breathe.ui.screens.ExploreScreen
 import com.sidharthify.breathe.ui.screens.HomeScreen
 import com.sidharthify.breathe.ui.screens.MapScreen
@@ -222,12 +227,11 @@ fun BreatheApp(
                 ) {
                     AppScreen.entries.forEach { screen ->
                         val isSelected = currentScreen == screen
-                        
+                        val targetShape=screen.shape
                         val iconColor by animateColorAsState(
                             targetValue = if (isSelected) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
                             label = "IconColor"
                         )
-                        
                         val pillColor by animateColorAsState(
                             targetValue = if (isSelected) MaterialTheme.colorScheme.secondaryContainer else Color.Transparent,
                             label = "PillColor"
@@ -241,13 +245,14 @@ fun BreatheApp(
                                 .expressiveClickable { currentScreen = screen },
                             contentAlignment = Alignment.Center
                         ) {
-                            Box(
-                                modifier = Modifier
-                                    .height(40.dp)
-                                    .width(64.dp)
-                                    .background(color = pillColor, shape = RoundedCornerShape(100))
+                            MorphingPill(
+                                isSelected = isSelected,
+                                from = MaterialShapes.Circle,
+                                to = targetShape, 
+                                color = pillColor,
+                                modifier = Modifier.size(50.dp)
                             )
-                            
+
                             Icon(
                                 if (isSelected) screen.iconFilled else screen.iconOutlined,
                                 contentDescription = screen.label,

--- a/app/src/main/java/com/sidharthify/breathe/navigation/Navigation.kt
+++ b/app/src/main/java/com/sidharthify/breathe/navigation/Navigation.kt
@@ -9,11 +9,23 @@ import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.Map
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialShapes.Companion.Puffy
+import androidx.compose.material3.MaterialShapes.Companion.Clover4Leaf
+import androidx.compose.material3.MaterialShapes.Companion.Slanted
+import androidx.compose.material3.MaterialShapes.Companion.SoftBurst
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.graphics.shapes.RoundedPolygon
 
-enum class AppScreen(val label: String, val iconFilled: ImageVector, val iconOutlined: ImageVector) {
-    Home("Home", Icons.Filled.Home, Icons.Outlined.Home),
-    Map("Map", Icons.Filled.Map, Icons.Outlined.Map),
-    Explore("Explore", Icons.Filled.Search, Icons.Outlined.Search),
-    Settings("Settings", Icons.Filled.Settings, Icons.Outlined.Settings)
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+enum class AppScreen(
+    val label: String,
+    val iconFilled: ImageVector,
+    val iconOutlined: ImageVector,
+    val shape: RoundedPolygon
+) {
+    Home("Home", Icons.Filled.Home, Icons.Outlined.Home, shape = Puffy),
+    Map("Map", Icons.Filled.Map, Icons.Outlined.Map, shape = Slanted),
+    Explore("Explore", Icons.Filled.Search, Icons.Outlined.Search, shape = Clover4Leaf),
+    Settings("Settings", Icons.Filled.Settings, Icons.Outlined.Settings, shape = SoftBurst)
 }

--- a/app/src/main/java/com/sidharthify/breathe/ui/components/MorphingPill.kt
+++ b/app/src/main/java/com/sidharthify/breathe/ui/components/MorphingPill.kt
@@ -1,0 +1,84 @@
+package com.sidharthify.breathe.ui.components
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.toPath
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.center
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Matrix
+import androidx.compose.ui.graphics.Path
+import androidx.graphics.shapes.Morph
+import androidx.graphics.shapes.RoundedPolygon
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun MorphingPill(
+    isSelected: Boolean,
+    from: RoundedPolygon,
+    to: RoundedPolygon,
+    color: Color,
+    modifier: Modifier = Modifier,
+) {
+    val morph = remember(from, to) {
+        Morph(from.normalized(), to.normalized())
+    }
+
+    val progress = remember { Animatable(0f) }
+
+    LaunchedEffect(isSelected) {
+        if (isSelected) {
+            progress.snapTo(0f)
+            kotlinx.coroutines.delay(120L)
+            progress.animateTo(
+                1f,
+                animationSpec = tween(300)
+            )
+        } else {
+            progress.snapTo(0f)
+        }
+    }
+
+    val path = remember { Path() }
+    val matrix = remember { Matrix() }
+
+    Box(
+        modifier = modifier
+            .drawWithContent {
+                val p = morph.toPath(
+                    progress = progress.value,
+                    path = path,
+                    startAngle = 0
+                )
+
+                processPath(
+                    path = p,
+                    size = size,
+                    scaleFactor = 1f,
+                    scaleMatrix = matrix
+                )
+
+                drawPath(path, color = color)
+            }
+    )
+}
+
+private fun processPath(
+    path: Path,
+    size: Size,
+    scaleFactor: Float,
+    scaleMatrix: Matrix = Matrix(),
+): Path {
+    scaleMatrix.reset()
+    scaleMatrix.apply { scale(x = size.width * scaleFactor, y = size.height * scaleFactor) }
+    path.transform(scaleMatrix)
+    path.translate(size.center - path.getBounds().center)
+    return path
+}


### PR DESCRIPTION
Changes
- Created MorphingPill component for animated shape transitions
- Replaced static pill with morphing shapes in navigation bar
- Assigned unique shapes to each screen:
  - Home: Puffy
  - Map: Slanted
  - Explore:Clover4Leaf
  - Settings: SoftBurst
- Morph starts from Circle to target shape on selection

Preview

https://github.com/user-attachments/assets/56ae7c43-8b03-4cb0-94e0-c62e2a4d52f7

