### PR TITLE
chore(build): enable configuration cache to speed up build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,4 @@ android.uniquePackageNames=false
 android.dependency.useConstraints=true
 android.r8.strictFullModeForKeepRules=false
 android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false
+org.gradle.configuration-cache=true


### PR DESCRIPTION
Got the suggestion to use `configuration-cache` to speed up build times while building Breathe.

### Comparison 
| Before | After |
|--------|--------|
| `353ms` | `121ms` | 

~3x faster
